### PR TITLE
Add dataset functionality to site

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,6 +4,8 @@
   href: /about
 - text: Collections
   href: /collection/search
+- text: Datasets
+  href: /dataset/search
 - text: Specimens
   href: /specimen/search
 - text: 100 Treasures

--- a/_includes/js/config.js
+++ b/_includes/js/config.js
@@ -74,7 +74,7 @@ var siteConfig = {
     mapbox: "GET_YOUR_OWN__TOKEN"
   },
   maps: {
-    locale: 'en', // we want to show the maps in japanese
+    locale: 'en',
     defaultProjection: 'MERCATOR',
     defaultMapStyle: 'BRIGHT',
     mapStyles: {

--- a/_includes/js/config.js
+++ b/_includes/js/config.js
@@ -6,44 +6,23 @@ var siteTheme = gbifReactComponents.themeBuilder.extend({
 });
 
 var siteConfig = {
+  version: 2,
   routes: {
-    collectionKey: {
-      route: '/collection/:key',
-      isHref: true,
-      url: ({ key }) => {
-        return `/collection/${key}`;
-      }
-    },
-    collectionSpecimens: {
-      route: '/collection/:key/specimens',
-      url: ({ key }) => `/collection/${key}/specimens`
-    },
-    occurrenceSearch: {
-      // The route you are currently using for occurrence search. The language prefix will be added automatically
-      // If you need special routes per language, then you have to add locale specific overwrites. The page language is available as a global variable called `pageLang`
-      route: '/specimen/search'
+    enabledRoutes: ['occurrenceSearch', 'collectionSearch', 'collectionKey', 'datasetSearch', 'datasetKey'], // what widgets do you include on your site. If not included we will link to gbif.org (for showing individual datasets for example)
+    occurrenceSearch: { // you can overwrite individual routes. 
+      route: '/specimen/search' // in this case we want the occurrence search to be available on a url that says specimens instead
     }
   },
-  collection: {
-    availableCatalogues: ['COLLECTION', 'OCCURRENCE'],
-    rootFilter: {
-      institution: 'c7d5c4da-9590-49c2-b87c-f0e7932611a6'
-    }
-  },
+  availableCatalogues: ['COLLECTION', 'DATASET', 'OCCURRENCE'],
   occurrence: {
     excludedFilters: ['occurrenceStatus', 'networkKey', 'hostingOrganizationKey', 'protocol', 'publishingCountryCode', 'institutionCode', 'collectionCode'],
-    highlightedFilters: ['taxonKey', 'verbatimScientificName', 'datasetKey', 'catalogNumber', 'recordedBy', 'identifiedBy'],
-    availableTableColumns: ['dataset', 'catalogNumber', 'country', 'year', 'recordedBy', 'identifiedBy'],
-    availableCatalogues: ['COLLECTION', 'OCCURRENCE'],
+    highlightedFilters: ['taxonKey', 'verbatimScientificName', 'institutionKey', 'collectionKey', 'catalogNumber', 'recordedBy', 'identifiedBy'],
+    defaultTableColumns: ['features', 'institutionKey', 'collectionKey', 'catalogNumber', 'country', 'year', 'recordedBy', 'identifiedBy'],
     mapSettings: {
       lat: 0,
       lng: 0,
       zoom: 0
     },
-    // You probably need help to configure the scope - so just ask
-    // for his demo site we only show Fungi (taxonKey=5). It use the predicate structure known from GBIF download API. 
-    // See https://www.gbif.org/developer/occurrence (long page without enough anchors - search for "Occurrence Download Predicates")
-    // The format is however slightly different, in that is use camelCase for keys instead of CONSTANT_CASE. 
     rootPredicate: {
       "type": "in",
       "key": "datasetKey",
@@ -59,26 +38,53 @@ var siteConfig = {
         'df9c8b86-9d36-4e29-91b3-4274dff053e5'
       ]
     },
-    // occurrenceSearchTabs: ['MAP', 'TABLE', 'GALLERY', 'DATASETS'] // what tabs should be shown
-    // see https://hp-theme.gbif-staging.org/data-exploration-config for more options
+    occurrenceSearchTabs: ['MAP', 'TABLE', 'GALLERY', 'DATASETS'] // what tabs should be shown
   },
-  availableCatalogues: ['COLLECTION', 'OCCURRENCE'],
+  collection: {
+    availableCatalogues: ['COLLECTION', 'OCCURRENCE', 'DATASET'],
+    rootFilter: {
+      institution: 'c7d5c4da-9590-49c2-b87c-f0e7932611a6'
+    }
+  },
+  dataset: {
+    rootFilter: {publishingOrg: 'b542788f-0dc2-4a2b-b652-fceced449591'},
+    highlightedFilters: ['q']
+  },
+  literature: {
+    rootFilter: {
+      predicate: {
+        type: 'or', predicates: [
+          {
+            type: 'in',
+            key: 'countriesOfResearcher',
+            values: ['US', 'UM', 'AS', 'FM', 'GU', 'MH', 'MP', 'PR', 'PW', 'VI']
+          },
+          {
+            type: 'in',
+            key: 'countriesOfCoverage',
+            values: ['US', 'UM', 'AS', 'FM', 'GU', 'MH', 'MP', 'PR', 'PW', 'VI']
+          }
+        ]
+      }
+    },
+    highlightedFilters: ['q', 'countriesOfResearcher', 'countriesOfCoverage', 'year']
+  },
   apiKeys: {
-    // maptiler: "INSERT_HERE",
-    // mapbox: "INSERT_HERE"
+    maptiler: "GET_YOUR_OWN_TOKEN", // https://github.com/gbif/hosted-portals/issues/229
+    mapbox: "GET_YOUR_OWN__TOKEN"
   },
   maps: {
-    // locale: 'ja',
+    locale: 'en', // we want to show the maps in japanese
     defaultProjection: 'MERCATOR',
     defaultMapStyle: 'BRIGHT',
     mapStyles: {
       ARCTIC: ['NATURAL', 'BRIGHT'],
       PLATE_CAREE: ['NATURAL', 'BRIGHT', 'DARK'],
-      MERCATOR: ['NATURAL', 'BRIGHT', 'DARK'],
+      MERCATOR: ['NATURAL', 'BRIGHT', 'SATELLITE', 'DARK'],
       ANTARCTIC: ['NATURAL', 'BRIGHT', 'DARK']
     }
   },
-  messages: {
+  messages: { // custom overwrites for the translations, e.g. label the occurrence catalog as a specimen catalog to match our data scope of specimens.
     "catalogues.occurrences": "Specimens"
   }
 };

--- a/pages/datasetKey.md
+++ b/pages/datasetKey.md
@@ -1,0 +1,6 @@
+---
+title: Dataset
+description: We publish open data
+permalink: /dataset/_key_
+layout: dataset-key
+---

--- a/pages/datasets.md
+++ b/pages/datasets.md
@@ -1,0 +1,7 @@
+---
+title: Datasets
+description: We publish open data
+permalink: /dataset/search
+layout: dataset
+noindex: true
+---


### PR DESCRIPTION
# Summary

There is a lot of flux at the moment in terms of GBIF organization, and in communication with Canadensys regarding this. Going forward, confident that dataset functionality will be needed, as our tetrapods and herbarium are split into 3 and 5 logistical components respectively, and we want to maintain those existing datasets and just bring them under the BBM institution and UBC herbarium collection.

## Main changes
The `config.js` file was updated to better align with the base template (a new version: 2 flag is now included, perhaps some upstream changes were made). For now, all datasets that fall with the UBC publisherOrg UUID are included. This is intentional to show stakeholders how things _currently_ are, to make more informed decisions around which datasets belong in BBM and which may actually belong to other units of the University. Additionally, I have included boilerplate literature scoping in `config.js` copied form another hp for formatting, but literature is not yet implemented and thus not accessible through any navigation links (see #9)

Standard `datasets.md` and `datasetKey.md` introduced to enable the layouts. Datasets link added to main nav link in header, and under `availableCatalogues` for both occurrences and collections.