### PR TITLE
Switch link in herbarium card to point to collection page

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -21,7 +21,7 @@ collectionsPreview:
     href: /collection/5aee131f-91dd-4b78-bfee-296f86801b7f
 
 
-polarBear:
+herbariumCard:
   reverse: false
   title: The Herbarium
   description: |      # required
@@ -31,8 +31,8 @@ polarBear:
   imageLicense: |
     [*Masonhalea richardsonii*, 2001](https://beaty-biodiversity-museum.hp.gbif-staging.org/specimen/search?entity=3311896307) Collected by Curtis Bjork, Lichenologist and Botanist at UBC
   cta:
-  - text: See all specimens
-    href: /under_development
+  - text: Go to collection
+    href: /collection/b44fcb7f-1227-4fa3-8ed2-de27aabb06e0
 
 
 specimens:

--- a/pages/home.md
+++ b/pages/home.md
@@ -27,7 +27,7 @@ composition:
   - type: features
     data: home.collectionsPreview
   - type: split
-    data: home.polarBear
+    data: home.herbariumCard
   - type: features
     data: home.specimens
 ---


### PR DESCRIPTION
The metadata for the herbarium has now been fixed so that records are showing under the appropriate collection code. Thus, we can now switch the link from `/under-development` to the collection page in the herbarium card on the homepage.

Additionally, switched the name of the component from `polarBear` to `herbariumCard` within `home.yml`