### PR TITLE
Adjust api calls for stats

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -54,7 +54,7 @@ stats:
   title: Our Data
   features:
       # Hard coded value
-    - title: <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?publishingOrg=b542788f-0dc2-4a2b-b652-fceced449591&country=CA">100,000</span>
+    - title: <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&country=CA">100,000</span>
       description: Canadian Specimens
       href: /specimen/search?country=CA
       blankTarget: true
@@ -62,7 +62,7 @@ stats:
       description: Total Citations
       href: /about
       blankTarget: true
-    - title: 37000
-      description: High Quality Images
+    - title: <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&mediaType=stillImage">100,000</span>
+      description: Records with Images
       href: /about
       blankTarget: true

--- a/pages/home.md
+++ b/pages/home.md
@@ -2,7 +2,7 @@
 lang-ref: home
 layout: home
 description: |
-  The Beaty Biodiversity Museum is Vancouver's natural history museum. <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?publishingOrg=b542788f-0dc2-4a2b-b652-fceced449591&limit=0">1,883</span> objects across <span data-ajax-url="https://api.gbif.org/v1/grscicoll/collection?institution=c7d5c4da-9590-49c2-b87c-f0e7932611a6">6</span> collections are currently available online, showcasing biodiversity from around the world.
+  The Beaty Biodiversity Museum is Vancouver's natural history museum. <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&limit=0">1,883</span> objects across <span data-ajax-url="https://api.gbif.org/v1/grscicoll/collection?institution=c7d5c4da-9590-49c2-b87c-f0e7932611a6">6</span> collections are currently available online, showcasing biodiversity from around the world.
 background: /assets/images/hero-image.jpg
 imageLicense: |
   [*No Title* David Gilbar, 2010](https://beaty-biodiversity-museum.hp.gbif-staging.org/specimen/search?entity=2571118608) All Rights Reserved, Beaty Biodiversity Museum


### PR DESCRIPTION
All api stats were adjusted and working as expected. For the citations, the only parameter that can be used directly from the api is for the publisherKey, which at this time includes the botanical gardens here at the university. I read over an issue from last year about using a graphql query instead to aggregate dataset citations, however this could also be inaccurate due to citations being counted more than once.

Will gather feedback on what statistic to display in place of the total citations, but for now will leave as is.