### PR TITLE
Remove filter function on text

### DIFF
--- a/_includes/js/config.js
+++ b/_includes/js/config.js
@@ -7,6 +7,7 @@ var siteTheme = gbifReactComponents.themeBuilder.extend({
 
 var siteConfig = {
   version: 2,
+  disableInlineTableFilterButtons: true,
   routes: {
     enabledRoutes: ['occurrenceSearch', 'collectionSearch', 'collectionKey', 'datasetSearch', 'datasetKey', 'institutionKey', 'institutionSearch'], 
     alwaysUseHrefs: true,


### PR DESCRIPTION
The ability to eliminate the filter function on text with the occurrence tables was introduced in https://github.com/gbif/gbif-web/commit/4da04910db77dd9728b18221da4c01b5ce25d165. This uses that feature by introducing `disableInlineTableFilterButtons: true` into `siteConfig`.

Issue raised in https://github.com/gbif/hosted-portals/issues/274

