### PR TITLE
Put z-index to 100 for nav menu to go over everything

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -19,7 +19,7 @@ $yellow-bg: #ececec;
   position:absolute;
   right: 0;
   padding: 1rem 2rem;
-  z-index: 50;
+  z-index: 70;
 }
 
 

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -19,7 +19,7 @@ $yellow-bg: #ececec;
   position:absolute;
   right: 0;
   padding: 1rem 2rem;
-  z-index: 70;
+  z-index: 100;
 }
 
 


### PR DESCRIPTION
Based on https://github.com/gbif/portal16/blob/master/app/views/components/map/mapWidget/mapWidget.styl, I think the highest z-index for the map components is 70, so 100 should go over it just fine.

```css
.mapWidget__controlsArea {
    z-index 70
    border-top 1px solid rgba(0, 0, 0, 0.2)
    background white
    height 40px
    &__toggleArea {
        float right
        margin 0 10px
        height 40px
        >a {
            font-size 18px
            line-height 40px
            width 30px
            text-align center
            display inline-block
            &.is-active {
                color $navBar_background_color
            }
        }
        >span {
            top -3px
            position relative
            left -5px
        }
    }
```