### PR TITLE
Remove issue filter on geo stat and link to MAP

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -7,10 +7,10 @@ stats:
       href: /specimen/search?country=CA
       blankTarget: true
       background: assets/icons/canadian-maple-leaf.svg
-    - title: <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&hasCoordinate=true&hasGeospatialIssue=false">400,000</span>
+    - title: <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&hasCoordinate=true">600,000</span>
       description: Georeferenced Records
       blankTarget: true
-      href: /specimen/search?hasCoordinate=true&hasGeospatialIssue=false
+      href: /specimen/search?view=MAP
       background: assets/icons/georeferenced-icon.svg
     - title: 1228
       description: Total Citations


### PR DESCRIPTION
There is still a dependency between the api stat call and the records viewed in the map, but this is an issue that needs to be addressed separately. It looks like there are still around 40,000 records that may not have BBM as their institution code, and are instead using one of the alternate codes. I will work to correct within the datasets in a later milestone.