### PR TITLE
Switch order of general search and catalog number search

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -7,15 +7,15 @@ description: |
     <div class="searchWrapper">
       <!-- Tab links -->
       <div class="tab">
-        <button class="tablinks active" onclick="openTab(event, 'searchTab_name')">Search by Catalogue Number</button>
-        <button class="tablinks" onclick="openTab(event, 'searchTab_catalogNumber')">
+        <button class="tablinks active" onclick="openTab(event, 'searchTab_name')">
           General search</button>
+        <button class="tablinks " onclick="openTab(event, 'searchTab_catalogNumber')">Search by Catalogue Number</button>
       </div>
 
       <!-- Tab content -->
       <div id="searchTab_name" class="tabcontent" style="display: block;">
         <form action="/specimen/search" method="GET">
-          <input name="catalogNumber" class="input" type="text" placeholder="Try M002500 or V1" style="width: 100%;">
+          <input id="home_specimen_input" name="q" class="input" type="text" placeholder="Try Vulpes vulpes" style="width: 100%;">
           <button type="submit" class="button is-ghost">
             <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg">
             <path fill="none" d="M0 0h24v24H0z"></path><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
@@ -26,7 +26,7 @@ description: |
 
       <div id="searchTab_catalogNumber" class="tabcontent">
         <form action="/specimen/search" method="GET">
-          <input id="home_specimen_input" name="q" class="input" type="text" placeholder="Try Vulpes vulpes" style="width: 100%;">
+          <input id="catalogNumber" name="catalogNumber" class="input" type="text" placeholder="Try M000001 or V1" style="width: 100%;">
           <button type="submit" class="button is-ghost" >
             <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg">
             <path fill="none" d="M0 0h24v24H0z"></path><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>


### PR DESCRIPTION
Upon feedback, switching the order of catalogNumber search and q search (General search) on the homepage. Scientific names of the form genus species appear to work well, so have used that as a placeholder. 

More sophisticated work could be done in the future, however I think having search (even with limitations) is better than no search at all.