### PR TITLE
Make sure all clickable links have aria labels

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -4,7 +4,7 @@
 # Columns (the more you add, the narrower they will be)
 columns:
   - description: |
-      [<img src="/assets/images/beaty-logo-horizontal.png"/>](https://beatymuseum.ubc.ca)
+      [<img alt="The Beaty Biodiversity logo" src="/assets/images/beaty-logo-horizontal.png"/>](https://beatymuseum.ubc.ca)
   - name: Contact
     description: | # Can be Markdown
       * 2212 Main Mall

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -33,7 +33,7 @@ collectionsPreview:
     Among our two million treasured specimens are the third-largest fish collection in Canada and a myriad of fossils, shells, insects, fungi, mammals, birds, reptiles, amphibians, and plants from around BC and across the world. If you would like to go to a particular dataset (such as Birds, Lichen, or Mammals) click on the red button below instead.
   cta:
   - text: View Individual Datasets
-    aria: "Got to datasets page"
+    aria: "Go to datasets page"
     href: /datasets
     isPrimary: true
   features: 

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -5,21 +5,25 @@ stats:
     - title: <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&country=CA">400,000</span>
       description: Canadian Specimens
       href: /specimen/search?country=CA
+      aria: "Search for all Canadian Specimens"
       blankTarget: true
       background: assets/icons/canadian-maple-leaf.svg
     - title: <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&hasCoordinate=true">600,000</span>
       description: Georeferenced Records
       blankTarget: true
       href: /specimen/search?view=MAP
+      aria: "Search for all georeferenced records"
       background: assets/icons/georeferenced-icon.svg
     - title: 1228
       description: Total Citations
       href: /about
+      aria: "Goes to the about page for the site"
       blankTarget: true
       background: assets/icons/citations-icon.svg
     - title: <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&mediaType=stillImage">37,000</span>
       description: Records with Images
       href: /specimen/search?mediaType=StillImage&view=GALLERY
+      aria: Show all specimens with images in gallery mode
       background: assets/icons/image-icon.svg
       blankTarget: true
 
@@ -29,6 +33,7 @@ collectionsPreview:
     Among our two million treasured specimens are the third-largest fish collection in Canada and a myriad of fossils, shells, insects, fungi, mammals, birds, reptiles, amphibians, and plants from around BC and across the world. If you would like to go to a particular dataset (such as Birds, Lichen, or Mammals) click on the red button below instead.
   cta:
   - text: View Individual Datasets
+    aria: "Got to datasets page"
     href: /datasets
     isPrimary: true
   features: 
@@ -36,11 +41,14 @@ collectionsPreview:
     description: Over half a million pinned specimens, 75,000 alcohol-preserved specimens and 25,000 specimens on slides showcase BC and the Yukon's spectacular insect diversity. Past collectors' particular projects have shaped the collection, and have resulted in particularly strong holdings of Hemiptera (true bugs), Odonata (dragonflies and damselflies), Siphonaptera (fleas) and Anoplura and Mallophaga (lice).
     background: assets/images/sec-card-image.jpg
     href: /collection/8f5f5b6f-28c6-44b4-8f21-98c55eaae203
+    aria: "Go to the specimen entomology collection"
   - title: Cowan Tetrapod Collection
     description: The Cowan Tetrapod Collection was founded in 1943, but the oldest specimen dates from 1849. With over 40,000 specimens representing over 2,500 species, the collection is the second-largest scientific collection of birds, mammals, reptiles, and amphibians in British Columbia.
     background: assets/images/ctc-card-image.jpg
     href: /collection/3b2ad644-b3e4-4ac9-a57f-23be3f86ed0e
+    aria: "Go to the cowan tetrapod collection"
   - title: UBC Herbarium
     description: The University of British Columbia Herbarium is the largest in western Canada and is home to over half a million plant specimens from around the world. This collection is critical to the identification, monitoring, and conservation of plant biodiversity in British Columbia, and is an important resource for scientific research and education.
     background: assets/images/herbarium-card-image.jpg
     href: /collection/b44fcb7f-1227-4fa3-8ed2-de27aabb06e0
+    aria: "Go to the UBC herbarium"

--- a/_includes/blocks/parts/feature.html
+++ b/_includes/blocks/parts/feature.html
@@ -1,0 +1,31 @@
+{% assign preTitle = include.preTitle | default: include.content.preTitle %}
+{% assign title = include.title | default: include.content.title %}
+{% assign description = include.description | default: include.content.description %}
+{% assign background = include.background | default: include.content.background %}
+{% assign cta = include.cta | default: include.content.cta %}
+{% assign center = include.center | default: include.content.center %}
+{% assign categories = include.categories | default: include.content.categories %}
+{% assign href = include.href | default: include.content.href %}
+{% assign blankTarget = include.blankTarget | default: include.content.blankTarget | default: false %}
+{% assign ratio = include.ratio %}
+{% assign useBackgroundImage = include.useBackgroundImage | default: false %}
+{% assign ignoreThumbor = include.ignoreThumbor | | default: include.content.ignoreThumbor | default: false %}
+{% assign aria = include.aria | default: include.content.aria}
+
+{% assign imageLicense = include.imageLicense | default: include.content.imageLicense %}
+{% if include.imageLicense == false %}
+  {% assign imageLicense = include.imageLicense %}
+{% endif %}
+
+{% include blocks/parts/featureImage.html background=background href=href aria=aria blankTarget=blankTarget imageLicense=imageLicense ratio=ratio useBackgroundImage=useBackgroundImage sizes=include.sizes ignoreThumbor=ignoreThumbor %}
+{% include blocks/parts/featureContent.html 
+  preTitle=preTitle 
+  href=href
+  aria=aria 
+  blankTarget=blankTarget 
+  title=title
+  description=description 
+  cta=cta
+  center=center
+  categories=categories
+  %}

--- a/_includes/blocks/parts/featureContent.html
+++ b/_includes/blocks/parts/featureContent.html
@@ -1,0 +1,57 @@
+{% assign preTitle = include.preTitle | default: include.content.preTitle %}
+{% assign title = include.title | default: include.content.title | default:"" | append: "" %}
+{% assign description = include.description | default: include.content.description %}
+{% assign imageLicense = include.imageLicense | default: include.content.imageLicense %}
+{% assign cta = include.cta | default: include.content.cta %}
+{% assign center = include.center | default: include.content.center %}
+{% assign categories = include.categories | default: include.content.categories %}
+{% assign href = include.href | default: include.content.href | default: false %}
+{% assign blankTarget = include.blankTarget | default: include.content.blankTarget | default: false %}
+{% assign aria = include.aria | default: include.content.aria | default: false %}
+
+{% if preTitle or title or description or cta %}
+<div class="feature-content {% if center %} feature-content--centered {% endif %}">
+  <div class="feature-text">
+    {% if href %}<a href="{{ href }}" aria-label="{{ aria }}" {% if blankTarget %}target="_blank"{% endif %} class="feature-overlay"></a>{% endif %}
+    {% if preTitle %} 
+    <div class="feature-pre-title">{{ preTitle }}</div>
+    {% endif %}
+    
+    {% if title %}
+    <h3 class="feature-title">
+      {% if href %}
+      <a href="{{ href }}" aria-label ="{{ aria }}" {% if blankTarget %}target="_blank"{% endif %}>{{ title | append: "" | liquify | markdownify }}</a>
+      {% else %}
+      {{ title | append: "" | liquify | markdownify }}
+      {% endif %}
+    </h3>
+    {% endif %}
+  </div>
+  
+  {% if description %}
+  <div class="feature-description">
+    {{ description | markdownify }}
+  </div>
+  {% endif %}
+
+  {% if cta %}
+  <div class="feature-cta">
+    {% for cta in cta %}
+    <a href="{{ cta.href | relative_url }}" aria-label = "{{ cta.aria }}" {% if cta.blankTarget %}target="_blank"{% endif %} class="button {% if cta.isPrimary %}is-primary{% else %}is-outlined{% endif %} {% if cta.klass %}{{cta.klass}}{% endif %}">{{ cta.text }}</a>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if categories %}
+  {% assign archive_permalink = site.data.languages[page.lang].archive_permalink | default: site.algae.archive_permalink %}
+  <div class="feature-categories">
+    <div class="tags">
+      {% for category in categories %}
+        <a class="tag is-light" href="{{ archive_permalink | relative_url }}?category={{ category | strip | url_encode }}">{{ category }}</a>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+</div>
+{% endif %}

--- a/_includes/blocks/parts/featureImage.html
+++ b/_includes/blocks/parts/featureImage.html
@@ -1,0 +1,51 @@
+{% assign background = include.background | default: include.content.background %}
+{% assign imageLicense = include.imageLicense | default: include.content.imageLicense %}
+{% assign href = include.href | default: include.content.href %}
+{% assign blankTarget = include.blankTarget | default: include.content.blankTarget | default: false %}
+{% assign ratio = include.ratio %}
+{% assign useBackgroundImage = include.useBackgroundImage %}
+{% assign aria = include.aria | default: include.content.aria %}
+
+{% if background %}
+{% assign background = background | liquify  %}
+<div class="feature-img" style="{% if useBackgroundImage %}background-image: url('{{ background }}'); {% endif %}{% if ratio %}padding-bottom: {{ratio}}%{% endif %}">
+  {% if useBackgroundImage != true %}
+    {% if site.thumbor and include.ignoreThumbor != true %}
+    <picture>
+        <source srcset="{% thumbor {{background | absolute_url}}, fit_in, width: 2000 %} 2000w, 
+                        {% thumbor {{background | absolute_url}}, fit_in, width: 1600 %} 1600w, 
+                        {% thumbor {{background | absolute_url}}, fit_in, width: 1200 %} 1200w, 
+                        {% thumbor {{background | absolute_url}}, fit_in, width: 1000 %} 1000w, 
+                        {% thumbor {{background | absolute_url}}, fit_in, width: 800 %} 800w, 
+                        {% thumbor {{background | absolute_url}}, fit_in, width: 500 %} 500w,
+                        {% thumbor {{background | absolute_url}}, fit_in, width: 10 %} 10w"
+                {% if include.sizes %}
+                sizes="{{ include.sizes }}"
+                {% endif %}
+                        >
+      <img  src="{{ background | absolute_url}}" 
+            srcset="{% thumbor {{background | absolute_url}}, fit_in, width: 2000 %} 2000w, 
+                    {% thumbor {{background | absolute_url}}, fit_in, width: 1600 %} 1600w, 
+                    {% thumbor {{background | absolute_url}}, fit_in, width: 1200 %} 1200w, 
+                    {% thumbor {{background | absolute_url}}, fit_in, width: 1000 %} 1000w, 
+                    {% thumbor {{background | absolute_url}}, fit_in, width: 800 %} 800w, 
+                    {% thumbor {{background | absolute_url}}, fit_in, width: 500 %} 500w,
+                    {% thumbor {{background | absolute_url}}, fit_in, width: 10 %} 10w"
+            {% if include.sizes %}
+            sizes="{{ include.sizes }}"
+            {% endif %}
+                    />
+    </picture>
+    {% else %}
+    <img src="{{ background | absolute_url}}" />
+    {% endif %}
+  {% endif %}
+  {% if href %}<a href="{{ href }}" aria-label="{{aria}}" {% if blankTarget %}target="_blank"{% endif %} class="feature-overlay"></a>{% endif %}
+  {% if imageLicense %}
+  <div class="feature-img-license">
+     <div class="feature-img-license-c"><span class="icon"><i class="fa fa-info-circle"></i></span> </div>
+     <div class="feature-img-license-text">{{ imageLicense | liquify | markdownify }}</div>
+  </div>
+  {% endif %}
+</div>
+{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,164 @@
+{% assign footer = site.data[page.lang].footer | default: site.data.footer %}
+
+<footer>
+  <div class="footer">
+    <div>
+      {% if page.layout != 'index' and page.lang-ref%}
+        {% assign posts = site.posts | where: "lang-ref", page.lang-ref | sort: 'lang' %}
+        {% if posts.size == 0 %}
+            {% assign posts=site.pages | where:"lang-ref", page.lang-ref | sort: 'lang' %}
+        {% endif %}
+        {% if posts.size > 1 %}
+        <div class="lang-options">
+            <em>{{ site.data.translations['differentLanguage'][page.lang] }}:</em>
+            <ul>
+            {% for post in posts %}
+            <li>
+              <a href="{{ site.base-url }}{{ post.url }}" class="{{ post.lang }}" title="View in {{post.lang}}">
+                <!-- {% if site.data.languages[post.lang].icon %}
+                <img src="{{ site.data.languages[post.lang].icon }}" style="margin-right: 6px; height:1em;" />
+                {% endif %} -->
+                {{ site.data.languages[post.lang].label }}
+              </a>
+            </li>
+            {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
+      {% endif %}
+    </div>
+    <div>
+      <div class="footer-groups">
+        {% for col in footer.columns %}
+        <div class="footer-column">
+          <p class="footer-column-name">{{ col.name }}</p>
+          {% if col.description %}
+          <div class="footer-description">
+            {{ col.description | markdownify }}
+          </div>
+          {% endif %}
+          {% if col.links %}
+          <ul class="footer-links">
+            {% for item in col.links %}
+            <li>
+              <a href="{{ item.href | relative_url}}">{{ item.text }}</a>
+            </li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+          
+          {% if col.connectIcons %}
+          <ul class="footer-online-list">
+            {% if site.twitter_username %}
+            <li>
+              <a href="https://twitter.com/{{ site.twitter_username }}">
+                <span class="fa-stack fa-lg">
+                  <i class="fa fa-circle fa-stack-2x"></i>
+                  <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
+                </span>
+              </a>
+            </li>
+            {% endif %}
+            {% if site.github_username %}
+            <li>
+              <a href="https://github.com/{{ site.github_username }}">
+                <span class="fa-stack fa-lg">
+                  <i class="fa fa-circle fa-stack-2x"></i>
+                  <i class="fa fa-github fa-stack-1x fa-inverse"></i>
+                </span>
+              </a>
+            </li>
+            {% endif %}
+            {% if site.youtube_username %}
+            <li>
+              <a href="https://www.youtube.com/user/{{ site.youtube_username }}">
+                <span class="fa-stack fa-lg">
+                  <i class="fa fa-circle fa-stack-2x"></i>
+                  <i class="fa fa-youtube fa-stack-1x fa-inverse"></i>
+                </span>
+              </a>
+            </li>
+            {% endif %}
+            {% if site.facebook_username %}
+            <li>
+              <a href="https://www.facebook.com/{{ site.facebook_username }}">
+                <span class="fa-stack fa-lg">
+                  <i class="fa fa-circle fa-stack-2x"></i>
+                  <i class="fa fa-facebook fa-stack-1x fa-inverse"></i>
+                </span>
+              </a>
+            </li>
+            {% endif %}
+            {% if site.flickr_username %}
+            <li>
+              <a href="https://www.flickr.com/photos/{{ site.flickr_username }}">
+                <span class="fa-stack fa-lg">
+                  <i class="fa fa-circle fa-stack-2x"></i>
+                  <i class="fa fa-flickr fa-stack-1x fa-inverse"></i>
+                </span>
+              </a>
+            </li>
+            {% endif %}
+          </ul>
+          {% endif %}
+
+        </div>
+        {% endfor %}
+      </div>
+
+      {% if footer.other %}
+      <div class="footer-footer">
+        {{ footer.other | markdownify }}
+      </div>
+      {% endif %}
+
+    </div>
+  </div>
+  <div class="footer-hostedby">
+    <div><a href="https://gbif.org/hosted-portals" aria-label="Go to the gbif hosted portals website"><img alt="A green leaf with white text that says 'hosted by GBIF'" src="/assets/theme/img/hostedby.svg"/></a></div>
+  </div>
+</footer>
+
+<script>
+  {% assign locale = site.locale | default: 'en' %};
+  var currentLocale = '{{ locale }}';
+</script>
+
+<script src="{{ '/assets/theme/js/script.js' | relative_url }}?v={{ site.time | date:'%s' }}"></script>
+
+{% if page.layout == 'archive' %}
+<script>
+  // On the news archive page we add a very rudimentary search, 
+  // by filtering in the client on categories
+  // 
+  // Filter cards on ?category=value
+  const urlParams = new URLSearchParams(window.location.search);
+    
+  if (urlParams.has("category") && urlParams.get("category") != "") {
+    var category = urlParams.get("category"); // Will return 1st category value + decode URI
+    
+    // filter features
+    var features = document.querySelectorAll('.feature');
+    features.forEach(function(feature){
+      var cardCategories = feature.attributes['data-categories'].value.split('|').map(function(x){return x.trim();});
+      // Hide card if it does not contain the selected category
+      if (!cardCategories.includes(category)) {
+        feature.style.display = 'none';
+      }
+    });
+
+    //show filter in top
+    var filterElement = document.getElementById('archive-filter');
+    if (filterElement) {
+      filterElement.innerHTML = '<div class="tags has-addons">' + 
+        '<a href="{{ site.algae.archive_permalink | relative_url }}" class="tag is-medium">' + category + '</a>' + 
+        '<a href="{{ site.algae.archive_permalink | relative_url }}" class="tag is-medium is-delete"></a>' +
+      '</div>'
+    }
+  }
+</script>
+{% endif %}
+
+{% if page.lastInBody %}
+  {{ page.lastInBody }}
+{% endif %}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,0 +1,129 @@
+{% assign navigation = site.data[page.lang].navigation | default: site.data.navigation %}
+
+{% assign navbar = page.navbar | default: site.algae.navbar %}
+
+{% assign floating = navbar.floating | default: false %}
+{% assign color = navbar.color %}
+{% assign hasWhiteText = navbar.hasWhiteText | default: false %}
+
+{% assign logo = site.data.languages[page.lang].logo | default: site.algae.logo %}
+
+{%- capture homeLang -%}
+  {%- if site.algae.rootLang != page.lang -%}{{ page.lang }}{%- endif -%}
+{%- endcapture -%}
+
+{% unless navigation or jekyll.environment == "production" %}
+<script>
+themeFeedback.push({title: "Missing navigation", description: "You haven't configured a navigation.", "link": "/feedback"})
+</script>
+{% endunless %}
+
+<nav class="navbar 
+  {% if floating %} navbar--floating{% endif %} 
+  {% if hasWhiteText %} navbar--hasWhiteText{% endif %} 
+  " 
+  {% if color %}style="background-color: {{ color }}"{% endif %}
+  role="navigation" aria-label="main navigation">
+  {% if site.testSite %}<div class="testSiteBanner"></div>{% endif %}
+  <div class="navbar-content">
+    <div class="navbar-brand">
+      <a class="navbar-item navbar-logo" href="{{ '/' | append: homeLang | relative_url }}">
+        {% if logo %}
+          <img class="navbar-logo_img" aria-label="button to go home" src="{{ logo | relative_url }}" height="28" />
+        {% if site.title and site.algae.logoAndTitle %}
+          <span class="navbar-logo_text">{{ site.title }}</span>
+        {% endif %}
+        {% else %}
+          <span class="navbar-item navbar-logo_text">{{ site.title }}</span>
+        {% endif %}
+      </a>
+
+      {% if navigation %}
+        <a
+          role="button"
+          id="navbarBurger"
+          class="navbar-burger burger menu-toggle"
+          aria-label="menu"
+          aria-expanded="false"
+          data-target="mainNavbar"
+        >
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
+      {% endif %}
+    </div>
+
+    {% if navigation %}
+    <div id="mainNavbar" class="navbar-menu">
+      <div class="navbar-start">
+        {% for item in navigation %}
+          {% if item.menu %}
+          <div class="navbar-top-item navbar-item has-dropdown is-hoverable">
+            <a class="navbar-link"> {{ item.text }} </a>
+
+            <div class="navbar-dropdown">
+              {% for subitem in item.menu %}
+                {% if subitem.href %}
+                  <a
+                    href="{{ subitem.href | relative_url }}"
+                    class="navbar-item {% if subitem.href == page.url %} active{% endif %}"
+                  >
+                    {{ subitem.text }}
+                  </a>
+                {% elsif subitem.text contains '---' %}
+                  <hr class="navbar-divider" />
+                {% else %}
+                  <h6 class="has-text-grey navbar-item">{{ subitem.text }}</h6>
+                {% endif %}
+              {% endfor %}
+            </div>
+          </div>
+          {% else %}
+            <a
+              class="navbar-top-item navbar-item"
+              href="{{ item.href | relative_url }}"
+            >
+            {{ item.text }}
+          </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+
+      {% if page.lang-ref%}
+        {% assign posts = site.posts | where: "lang-ref", page.lang-ref | sort: 'lang' %}
+        {% if posts.size == 0 %}
+            {% assign posts=site.pages | where:"lang-ref", page.lang-ref | sort: 'lang' %}
+        {% endif %}
+        {% if posts.size > 1 %}
+
+        <div class="navbar-end">
+          <div class="navbar-item has-dropdown is-hoverable">
+            <div class="buttons language-selector">
+              <a class="button is-light">
+                <span>{{ site.data.languages[page.lang].label }}</span>
+                <span class="icon is-small">
+                  <i class="fa fa-language"></i>
+                </span>
+              </a>
+
+              <div class="navbar-dropdown is-right">
+                {% for post in posts %}
+                <a class="navbar-item" href="{{ site.base-url }}{{ post.url }}">
+                  {% if site.data.languages[post.lang].icon %}
+                  <img src="{{ site.data.languages[post.lang].icon }}" style="margin-right: 6px; height:1em;" />
+                  {% endif %}
+                  {{ site.data.languages[post.lang].label }}
+                </a>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+        </div>
+        {% endif %}
+      {% endif %}
+      
+    </div>
+  </div>
+  {% endif %}
+</nav>


### PR DESCRIPTION
Here I have adapted some of the base components from hp-jekyll-theme to take `aria` as an argument/parameter (not sure what they are called in jekyll). I will probably use the same approach for image alt texts. Not sure if the way I have implemented it is the way it is supposed to be done, but it seems to work as intended when browsing the site with the firefox accessibility inspector. I will read up on what the best phrasing is for said aria-labels, but now the underlying technical bits appear to be working.

Note that this only covers the root page. I am not sure what to do with 

```
columns:
  - description: |
      [<img alt="The Beaty Biodiversity logo" src="/assets/images/beaty-logo-horizontal.png"/>](https://beatymuseum.ubc.ca)
```

I believe that right now the alt text gets carried over as the aria-label but will have to investigate.





