### PR TITLE
Use github alt text bot to flag images that are used in this repo without alt text being added

### DIFF
--- a/.github/workflows
+++ b/.github/workflows
@@ -1,0 +1,26 @@
+name: Accessibility-alt-text-bot
+on: 
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  accessibility_alt_text_bot:
+    name: Check alt text is set on issue or pull requests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion }}
+    steps:
+      - name: Get action 'github/accessibility-alt-text-bot'
+        uses: github/accessibility-alt-text-bot@v1.2.0 # Set to latest


### PR DESCRIPTION
@MortenHofft I have assigned you as reviewer to this PR as this repo isn't technically under our organization, and so performing actions that use GitHub workflows seems like it should be okayed by you first before being merged.

This workflow will run the https://github.com/marketplace/actions/accessibility-alt-text-bot whenever someone attaches an image to an issue, pull request, or discussion in this repo without adding alt text (as I have definitely been guilty of with things like screenshots, as I think many developers are). It looks like the following when triggered:

![Screenshot of what will be displayed by the alt text bot](https://github.blog/wp-content/uploads/2023/06/alt-text-bot.png?w=1024&resize=1024%2C308)

For a blog post from the github developers that developed this bot, see [their blog post announcing it](https://github.blog/2023-06-12-make-your-github-projects-more-accessible-with-accessibility-alt-text-bot/)