### PR TITLE
Add roles and aria-levels to site description on the homepage

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -2,7 +2,7 @@
 lang-ref: home
 layout: home
 description: |
-  <p class="tagLine">The Beaty Biodiversity Museum is Vancouver's natural history museum. <span data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&limit=0">641,448</span> objects across 3 collections are currently available online, showcasing biodiversity from around the world.</p>
+  <p role="heading" aria-level="2" class="tagLine">The Beaty Biodiversity Museum is Vancouver's natural history museum. <span role="heading" aria-level="2" data-ajax-url="https://api.gbif.org/v1/occurrence/search?institutionCode=BBM&limit=0">641,448</span> objects across 3 collections are currently available online, showcasing biodiversity from around the world.</p>
 
     <div class="searchWrapper">
       <!-- Tab links -->


### PR DESCRIPTION
Added `role="heading"` and `aria-level="2"` to both the `<p>` tag and the `<span>` tag used within the homepage. I used the following resources to determine the values for these, however will confirm with the accessibility checker if I have implemented correctly.

Resources:
- [W3C Aria Standard](https://www.w3.org/TR/wai-aria/#heading)