### PR TITLE
Switch plausible to head

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,10 +40,6 @@ privacy:
   contactEmail: info@gbif.org
   helpdeskEmail: info@gbif.org
 
-plausible:
-  enabled: true
-  dataDomain: "collections.beatymuseum.ubc.ca"
-
 algae:
   hideHelper: true # set to false or delete line  to show feedback during development
   rootLang: en

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,11 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
+<script
+  defer
+  data-domain="collections.beatymuseum.ubc.ca"
+  src="https://plausible.io/js/script.js"
+></script>
+
 <!-- Favicon -->
-<link rel="icon" href="/favicon.svg">
-
-
+<link rel="icon" href="/favicon.svg" />


### PR DESCRIPTION
Switch the script to be in the html head, because the previous config just adds it there anyways based on

```js
{% if site.plausible.enabled %}
  <script defer data-domain="{{ site.plausible.dataDomain }}" src="https://plausible.io/js/script.js"></script>
{% endif %}
```

This just cuts out a step